### PR TITLE
fix: add pnpm-store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.pnpm-store/
 .turbo/
 dist/
 node_modules/


### PR DESCRIPTION
This was causing an issue when versioning. All the files in the pnpm-store were being added to the commit.
